### PR TITLE
feat: add show_average parameter to plot functions (closes #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ===========
 
+0.1.13
+-------
+- Added ``show_average`` parameter (default ``True``) to
+  ``plot_support_resistance`` and ``plot_sup_res_date``; set to ``False`` to
+  hide the average support/resistance lines from the plot (closes #16)
+
 0.1.12
 -------
 - `calc_support_resistance` and `get_extrema` now accept string names for their

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ with io.open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='trendln',
-    version="0.1.12",
+    version="0.1.13",
     description='Support and Resistance Trend lines Calculator for Financial Analysis',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/test_trendln.py
+++ b/tests/test_trendln.py
@@ -19,6 +19,7 @@ from trendln import (
     get_extrema,
     get_levels,
     pandas_to_ohlc,
+    plot_support_resistance,
     METHOD_NAIVE,
     METHOD_NAIVECONSEC,
     METHOD_NUMDIFF,
@@ -249,6 +250,42 @@ class TestGetExtrema:
 # ---------------------------------------------------------------------------
 # Input validation
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# plot_support_resistance options
+# ---------------------------------------------------------------------------
+
+import os
+os.environ.setdefault('MPLBACKEND', 'Agg')
+
+class TestPlotOptions:
+    """Tests for plot_support_resistance keyword parameters."""
+
+    def test_show_average_true_returns_figure(self):
+        import matplotlib
+        fig = plot_support_resistance(DATA_SIMPLE, show_average=True)
+        assert isinstance(fig, matplotlib.figure.Figure)
+
+    def test_show_average_false_returns_figure(self):
+        import matplotlib
+        fig = plot_support_resistance(DATA_SIMPLE, show_average=False)
+        assert isinstance(fig, matplotlib.figure.Figure)
+
+    def test_show_average_false_fewer_lines(self):
+        """With show_average=False the average lines (Avg. Support/Resistance)
+        should not appear as legend entries."""
+        import matplotlib
+        import matplotlib.pyplot as plt
+        plt.figure()
+        fig_with = plot_support_resistance(DATA_SIMPLE, show_average=True)
+        labels_with = [t.get_text() for t in fig_with.axes[0].get_legend().get_texts()]
+        plt.figure()
+        fig_without = plot_support_resistance(DATA_SIMPLE, show_average=False)
+        labels_without = [t.get_text() for t in fig_without.axes[0].get_legend().get_texts()]
+        plt.close('all')
+        assert any('Avg.' in l for l in labels_with)
+        assert not any('Avg.' in l for l in labels_without)
+
 
 class TestValidation:
     def test_invalid_h_type(self):

--- a/trendln/__init__.py
+++ b/trendln/__init__.py
@@ -942,17 +942,20 @@ def get_levels(calc_result, x, price, n=3):
 def plot_sup_res_date(hist, idx, numbest = 2, fromwindows = True, pctbound=0.1,
                       extmethod = METHOD_NUMDIFF, method=METHOD_NSQUREDLOGN, window=125,
                       errpct = 0.005, hough_scale=0.01, hough_prob_iter=10, sortError=False, accuracy=2,
-                      title='Prices with Support/Resistance Trend Lines', y_axis_label='Price', series_label=None):
+                      title='Prices with Support/Resistance Trend Lines', y_axis_label='Price', series_label=None,
+                      show_average=True):
     import matplotlib.ticker as ticker
     return plot_support_resistance(hist, ticker.FuncFormatter(datefmt(idx)), numbest, fromwindows,
                                    pctbound, extmethod, method, window, errpct, hough_scale,
                                    hough_prob_iter, sortError, accuracy,
-                                   title=title, y_axis_label=y_axis_label, series_label=series_label)
+                                   title=title, y_axis_label=y_axis_label, series_label=series_label,
+                                   show_average=show_average)
 
 def plot_support_resistance(hist, xformatter = None, numbest = 2, fromwindows = True,
                             pctbound=0.1, extmethod = METHOD_NUMDIFF, method=METHOD_NSQUREDLOGN,
                             window=125, errpct = 0.005, hough_scale=0.01, hough_prob_iter=10, sortError=False, accuracy=2,
-                            title='Prices with Support/Resistance Trend Lines', y_axis_label='Price', series_label=None):
+                            title='Prices with Support/Resistance Trend Lines', y_axis_label='Price', series_label=None,
+                            show_average=True):
     import matplotlib.pyplot as plt
     import matplotlib.ticker as ticker
     ret = calc_support_resistance(hist, extmethod, method, window, errpct, hough_scale, hough_prob_iter, sortError, accuracy)
@@ -987,7 +990,8 @@ def plot_support_resistance(hist, xformatter = None, numbest = 2, fromwindows = 
         plt.plot(range(len_h), hist[1 if hist[0] is None else 0], 'k--', label= ('High' if hist[0] is None else 'Low') + ' Price')
     for h, idxs, pm, clrp, lbl, clrl in disp:
         plt.plot(idxs, [h[x] for x in idxs], clrp)
-        plt.plot([0, len_h-1],[pm[1],pm[0] * (len_h-1) + pm[1]],clrl, label=lbl)
+        if show_average:
+            plt.plot([0, len_h-1],[pm[1],pm[0] * (len_h-1) + pm[1]],clrl, label=lbl)
     def add_trend(h, trend, lbl, clr, bFirst):
         for ln in trend[:numbest]:
             maxx = ln[0][-1]+1


### PR DESCRIPTION
plot_support_resistance and plot_sup_res_date now accept show_average=True (default, preserves existing behaviour) or show_average=False to hide the overall average support/resistance lines from the plot.